### PR TITLE
[BST-2364] Debug snyk and exit on error from snyk

### DIFF
--- a/scanners/boostsecurityio/snyk-scanner/module.yaml
+++ b/scanners/boostsecurityio/snyk-scanner/module.yaml
@@ -58,5 +58,5 @@ steps:
       format: sarif
       post-processor:
         docker:
-            image: boost-scanner-snyk:devel
+            image: public.ecr.aws/boostsecurityio/boost-scanner-snyk:6486a90@sha256:fcd6c7a780dbf29129f580fe1f3a3af0d1b906a4574ac5403079f9de0a700bd6
             command: process

--- a/scanners/boostsecurityio/snyk-scanner/module.yaml
+++ b/scanners/boostsecurityio/snyk-scanner/module.yaml
@@ -33,6 +33,10 @@ setup:
             arch="snyk-linux-arm64"
             sha="b3c074f98368a1dd5d06d78f29db1a721f31f2ba5171e694b67fba3c27ba818a  snyk-linux-arm64"
             ;;
+          arm64-linux)
+            arch="snyk-macos"
+            sha="a6c7aec91cf67223acd7f2b6e2b793f9ddd70649e1740462bd1af65476c78b4f  snyk-macos"
+            ;;        
           *)
             echo "Unsupported machine: ${machine}"
             exit 1
@@ -49,9 +53,14 @@ setup:
 steps:
   - scan:
       command:
-          run: $SETUP_PATH/snyk test --json || true
+          run: |
+            $SETUP_PATH/snyk test --json --all-projects
+            status=$?
+            if [ $status -ne 0 ] || [[ $status -ne 1 ]]; then
+              exit $status
+            fi
       format: sarif
       post-processor:
         docker:
-            image: public.ecr.aws/boostsecurityio/boost-scanner-snyk:6486a90@sha256:fcd6c7a780dbf29129f580fe1f3a3af0d1b906a4574ac5403079f9de0a700bd6
+            image: boost-scanner-snyk:devel
             command: process

--- a/scanners/boostsecurityio/snyk-scanner/module.yaml
+++ b/scanners/boostsecurityio/snyk-scanner/module.yaml
@@ -32,11 +32,7 @@ setup:
           aarch64-linux)
             arch="snyk-linux-arm64"
             sha="b3c074f98368a1dd5d06d78f29db1a721f31f2ba5171e694b67fba3c27ba818a  snyk-linux-arm64"
-            ;;
-          arm64-linux)
-            arch="snyk-macos"
-            sha="a6c7aec91cf67223acd7f2b6e2b793f9ddd70649e1740462bd1af65476c78b4f  snyk-macos"
-            ;;        
+            ;;    
           *)
             echo "Unsupported machine: ${machine}"
             exit 1

--- a/scanners/boostsecurityio/snyk-scanner/module.yaml
+++ b/scanners/boostsecurityio/snyk-scanner/module.yaml
@@ -54,7 +54,8 @@ steps:
   - scan:
       command:
           run: |
-            $SETUP_PATH/snyk test --json --all-projects || true
+            $SETUP_PATH/snyk test --json --all-projects || ecode=$?
+            [ ${ecode:-0} -lt 2 ] || exit $ecode
       format: sarif
       post-processor:
         docker:

--- a/scanners/boostsecurityio/snyk-scanner/module.yaml
+++ b/scanners/boostsecurityio/snyk-scanner/module.yaml
@@ -54,11 +54,7 @@ steps:
   - scan:
       command:
           run: |
-            $SETUP_PATH/snyk test --json --all-projects
-            status=$?
-            if [ $status -ne 0 ] || [[ $status -ne 1 ]]; then
-              exit $status
-            fi
+            $SETUP_PATH/snyk test --json --all-projects || true
       format: sarif
       post-processor:
         docker:

--- a/scanners/boostsecurityio/snyk-scanner/module.yaml
+++ b/scanners/boostsecurityio/snyk-scanner/module.yaml
@@ -60,3 +60,5 @@ steps:
         docker:
             image: public.ecr.aws/boostsecurityio/boost-scanner-snyk:6486a90@sha256:fcd6c7a780dbf29129f580fe1f3a3af0d1b906a4574ac5403079f9de0a700bd6
             command: process
+            environment:
+                PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/snyk-scanner/module.yaml
+++ b/scanners/boostsecurityio/snyk-scanner/module.yaml
@@ -32,7 +32,7 @@ setup:
           aarch64-linux)
             arch="snyk-linux-arm64"
             sha="b3c074f98368a1dd5d06d78f29db1a721f31f2ba5171e694b67fba3c27ba818a  snyk-linux-arm64"
-            ;;    
+            ;;
           *)
             echo "Unsupported machine: ${machine}"
             exit 1


### PR DESCRIPTION
- set `PYTHONIOENCODING` to `utf-8` so that stdin is read using utf-8 encoding
- capture the exit code of the snyk command so that we exit if the exit code is > 1 (https://docs.snyk.io/snyk-cli/commands/test#exit-codes)
- add `--all-projects` as param so that the snyk cli scans all projects in repo