### PR TITLE
Native Scanner id shall be the same as legacy

### DIFF
--- a/scanners/boostsecurityio/native-scanner/module.yaml
+++ b/scanners/boostsecurityio/native-scanner/module.yaml
@@ -1,7 +1,7 @@
 api_version: 1.0
 
 
-id: native-scanner
+id: scanner
 name: Boost Native Scanner
 namespace: default
 


### PR DESCRIPTION
We need to align with legacy as much as possible. 
`id` shall be `scanner`, for namespace `default`

This has been tested here
https://github.com/boost-sandbox/insecure-code/blob/main/.github/workflows/boost.yml

On Prod `sandbox` account