### PR TITLE
[Security] - Only listen to push on main branch, which is protected

### DIFF
--- a/.github/workflows/registry-scanner.yaml
+++ b/.github/workflows/registry-scanner.yaml
@@ -3,12 +3,10 @@ on:
   push:
     branches:
       - main
-      - master
 
   pull_request:
     branches:
       - main
-      - master
     types:
       - opened
       - synchronize


### PR DESCRIPTION
We shall only listen on pushes on `main` branch, that's the only "Protected branch", the `master` branch is NOT protected so in theory anyone on the public internet (this repo being public) could create a PR with their custom branch name `master`... and the action would kick in and upload !

Also, we should tighten this to only upload on `main`,  not any `push`
https://github.com/boostsecurityio/scanner-registry-action/blob/c1762b2c075c564acb942705b36dcadc41d8fe19/action.yaml#L40