### PR TITLE
brakeman - add --force flag

### DIFF
--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -12,7 +12,7 @@ steps:
       command:
         docker:
           image: presidentbeef/brakeman:latest@sha256:7416e4cf46131d5f920be496485d30d55a9b9f00acec28847ae1e5f10ac837f4
-          command: --format json --quiet --no-pager --no-exit-on-warn --no-exit-on-error /src
+          command: --format json --quiet --no-pager --no-exit-on-warn --no-exit-on-error --force /src
           workdir: /src
       format: sarif
       post-processor:

--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -6,6 +6,7 @@ namespace: boostsecurityio/brakeman
 
 config:
   support_diff_scan: true
+  require_full_repo: true
 
 steps:
   - scan:


### PR DESCRIPTION
This forces scan even if ./app is not found

See logs here
https://github.com/boost-entropy-ruby/WhatWeb/actions/runs/3246689816/jobs/5325734062#step:3:34

Drive-by: add `require_full_repo`