### PR TITLE
trivy-image : ignore unfixed CVEs by default

### DIFF
--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -50,7 +50,7 @@ steps:
       command:
         environment:
           IMAGE_NAME: ${BOOST_IMAGE_NAME}
-          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:--ignore-unfixed}
+          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS---ignore-unfixed}
         run: |
             $SETUP_PATH/trivy image ${TRIVY_ADDITIONAL_ARGS} --format json --security-checks vuln \
               --quiet ${BOOST_IMAGE_NAME}

--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -50,7 +50,7 @@ steps:
       command:
         environment:
           IMAGE_NAME: ${BOOST_IMAGE_NAME}
-          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:--ignored-unfixed}
+          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:--ignore-unfixed}
         run: |
             $SETUP_PATH/trivy image ${TRIVY_ADDITIONAL_ARGS} --format json --security-checks vuln \
               --quiet ${BOOST_IMAGE_NAME}

--- a/scanners/boostsecurityio/trivy-image/module.yaml
+++ b/scanners/boostsecurityio/trivy-image/module.yaml
@@ -50,8 +50,9 @@ steps:
       command:
         environment:
           IMAGE_NAME: ${BOOST_IMAGE_NAME}
+          TRIVY_ADDITIONAL_ARGS: ${TRIVY_ADDITIONAL_ARGS:--ignored-unfixed}
         run: |
-            $SETUP_PATH/trivy image --format json --security-checks vuln \
+            $SETUP_PATH/trivy image ${TRIVY_ADDITIONAL_ARGS} --format json --security-checks vuln \
               --quiet ${BOOST_IMAGE_NAME}
       format: sarif
       post-processor:


### PR DESCRIPTION
Trivy has an option to hide the CVEs for which there is no known patch
https://aquasecurity.github.io/trivy/v0.32/docs/vulnerability/examples/filter/#hide-unfixed-vulnerabilities

Zaid has suggested we make that the sane default configuration, but still allow for someone to override it (through environment variable)

----
Tested here

Before
https://github.com/boost-sandbox/insecure-code/actions/runs/3268041359/jobs/5373979552#step:5:45

After
https://github.com/boost-sandbox/insecure-code/actions/runs/3268548255/jobs/5375082836#step:5:41