### PR TITLE
brakeman: normalize CWE rules and fix SARIF ruleId mapping

### DIFF
--- a/scanners/boostsecurityio/brakeman/module.yaml
+++ b/scanners/boostsecurityio/brakeman/module.yaml
@@ -18,4 +18,4 @@ steps:
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-brakeman:951712d@sha256:335e67fcb7d40cb51d1ea54d17d85269f6da87520d592889e1cbba87e6ddaf28
+          image: public.ecr.aws/boostsecurityio/boost-scanner-brakeman:bd7f92b@sha256:6e1d93752c2be696a2af2f1938c162bb7b54f5f171f6218e62591460b56dcd88

--- a/scanners/boostsecurityio/brakeman/rules.yaml
+++ b/scanners/boostsecurityio/brakeman/rules.yaml
@@ -1,307 +1,307 @@
 rules:
-  cwe-1004:
+  CWE-1004:
     categories:
       - ALL
       - cwe-1004
     description: The software uses a cookie to store sensitive information, but the cookie is not marked with the HttpOnly flag.
-    group: Community Scanners
-    name: cwe-1004
-    pretty_name: "CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag"
+    group: CWE Top 25
+    name: CWE-1004
+    pretty_name: CWE-1004 - Sensitive Cookie Without 'HttpOnly' Flag
     ref: https://cwe.mitre.org/data/definitions/1004.html
-  cwe-1022:
+  CWE-1022:
     categories:
       - ALL
       - cwe-1022
     description: The web application produces links to untrusted external sites outside of its sphere of control, but it does not properly prevent the external site from modifying security-critical properties of the window.opener object, such as the location property.
-    group: Community Scanners
-    name: cwe-1022
-    pretty_name: "CWE-1022: Missing Reverse-Tabnabbing Protection"
+    group: CWE Top 25
+    name: CWE-1022
+    pretty_name: CWE-1022 - Missing Reverse-Tabnabbing Protection
     ref: https://cwe.mitre.org/data/definitions/1022.html
-  cwe-1104:
+  CWE-1104:
     categories:
       - ALL
       - cwe-1104
     description: The product relies on third-party components that are not actively supported or maintained by the original developer or a trusted proxy for the original developer.
-    group: Community Scanners
-    name: cwe-1104
-    pretty_name: "CWE-1104: Use of Unmaintained Third Party Components"
+    group: CWE Top 25
+    name: CWE-1104
+    pretty_name: CWE-1104 - Use of Unmaintained Third Party Components
     ref: https://cwe.mitre.org/data/definitions/1104.html
-  cwe-125:
+  CWE-125:
     categories:
       - ALL
       - cwe-125
     description: The software reads data past the end, or before the beginning, of the intended buffer.
-    group: Community Scanners
-    name: cwe-125
-    pretty_name: "CWE-125: Out-of-bounds Read"
+    group: CWE Top 25
+    name: CWE-125
+    pretty_name: CWE-125 - Out-of-bounds Read
     ref: https://cwe.mitre.org/data/definitions/125.html
-  cwe-1254:
+  CWE-1254:
     categories:
       - ALL
       - cwe-1254
     description: The comparison logic is performed over a series of steps rather than across the entire string in one operation. If there is a comparison logic failure, the operation may be vulnerable to a timing attack that can result in the interception of the process.
-    group: Community Scanners
-    name: cwe-1254
-    pretty_name: "CWE-1254: Incorrect Comparison Logic Granularity"
+    group: CWE Top 25
+    name: CWE-1254
+    pretty_name: CWE-1254 - Incorrect Comparison Logic Granularity
     ref: https://cwe.mitre.org/data/definitions/1254.html
-  cwe-1336:
+  CWE-1336:
     categories:
       - ALL
       - cwe-1336
     description: The product uses a template engine to insert or process externally-influenced input, but it does not neutralize or incorrectly neutralizes special elements or syntax that can be interpreted as template expressions or other code directives when processed.
-    group: Community Scanners
-    name: cwe-1336
-    pretty_name: "CWE-1336: Improper Neutralization of Special Elements Used in a Template Engine"
+    group: CWE Top 25
+    name: CWE-1336
+    pretty_name: CWE-1336 - Improper Neutralization of Special Elements Used in a Template Engine
     ref: https://cwe.mitre.org/data/definitions/1336.html
-  cwe-185:
+  CWE-185:
     categories:
       - ALL
       - cwe-185
     description: The software specifies a regular expression in a way that causes data to be improperly matched or compared.
-    group: Community Scanners
-    name: cwe-185
-    pretty_name: "CWE-185: Incorrect Regular Expression"
+    group: CWE Top 25
+    name: CWE-185
+    pretty_name: CWE-185 - Incorrect Regular Expression
     ref: https://cwe.mitre.org/data/definitions/185.html
-  cwe-20:
+  CWE-20:
     categories:
       - ALL
       - cwe-20
     description: The product receives input or data, but it does not validate or incorrectly validates that the input has the properties that are required to process the data safely and correctly.
-    group: Community Scanners
-    name: cwe-20
-    pretty_name: "CWE-20: Improper Input Validation"
+    group: CWE Top 25
+    name: CWE-20
+    pretty_name: CWE-20 - Improper Input Validation
     ref: https://cwe.mitre.org/data/definitions/20.html
-  cwe-200:
+  CWE-200:
     categories:
       - ALL
       - cwe-200
     description: The product exposes sensitive information to an actor that is not explicitly authorized to have access to that information.
-    group: Community Scanners
-    name: cwe-200
-    pretty_name: "CWE-200: Exposure of Sensitive Information"
+    group: CWE Top 25
+    name: CWE-200
+    pretty_name: CWE-200 - Exposure of Sensitive Information
     ref: https://cwe.mitre.org/data/definitions/200.html
-  cwe-22:
+  CWE-22:
     categories:
       - ALL
       - cwe-22
     description: The software uses external input to construct a pathname that is intended to identify a file or directory that is located underneath a restricted parent directory, but the software does not properly neutralize special elements within the pathname.
-    group: Community Scanners
-    name: cwe-22
-    pretty_name: "CWE-22: Path Traversal"
+    group: CWE Top 25
+    name: CWE-22
+    pretty_name: CWE-22 - Path Traversal
     ref: https://cwe.mitre.org/data/definitions/22.html
-  cwe-259:
+  CWE-259:
     categories:
       - ALL
       - cwe-259
     description: The software contains a hard-coded password, which it uses for its own inbound authentication or for outbound communication to external components.
-    group: Community Scanners
-    name: cwe-259
-    pretty_name: "CWE-259: Use of Hard-coded Password"
+    group: CWE Top 25
+    name: CWE-259
+    pretty_name: CWE-259 - Use of Hard-coded Password
     ref: https://cwe.mitre.org/data/definitions/259.html
-  cwe-284:
+  CWE-284:
     categories:
       - ALL
       - cwe-284
     description: The software does not restrict or incorrectly restricts access to a resource from an unauthorized actor.
-    group: Community Scanners
-    name: cwe-284
-    pretty_name: "CWE-284: Improper Access Control"
+    group: CWE Top 25
+    name: CWE-284
+    pretty_name: CWE-284 - Improper Access Control
     ref: https://cwe.mitre.org/data/definitions/284.html
-  cwe-285:
+  CWE-285:
     categories:
       - ALL
       - cwe-285
     description: The software does not perform or incorrectly performs an authorization check when an actor attempts to access a resource or perform an action.
-    group: Community Scanners
-    name: cwe-285
-    pretty_name: "CWE-285: Improper Authorization"
+    group: CWE Top 25
+    name: CWE-285
+    pretty_name: CWE-285 - Improper Authorization
     ref: https://cwe.mitre.org/data/definitions/285.html
-  cwe-287:
+  CWE-287:
     categories:
       - ALL
       - cwe-287
     description: When an actor claims to have a given identity, the software does not prove or insufficiently proves that the claim is correct.
-    group: Community Scanners
-    name: cwe-287
-    pretty_name: "CWE-287: Improper Authentication on Critical Resource"
+    group: CWE Top 25
+    name: CWE-287
+    pretty_name: CWE-287 - Improper Authentication on Critical Resource
     ref: https://cwe.mitre.org/data/definitions/287.html
-  cwe-311:
+  CWE-311:
     categories:
       - ALL
       - cwe-311
     description: The software does not encrypt sensitive or critical information before storage or transmission.
-    group: Community Scanners
-    name: cwe-311
-    pretty_name: "CWE-311: Missing Encryption of Sensitive Data"
+    group: CWE Top 25
+    name: CWE-311
+    pretty_name: CWE-311 - Missing Encryption of Sensitive Data
     ref: https://cwe.mitre.org/data/definitions/311.html
-  cwe-328:
+  CWE-328:
     categories:
       - ALL
       - cwe-328
     description: The product uses an algorithm that produces a digest that does not meet security expectations for a hash function that allows a preimage attack, find another input that can produce the same hash (2nd preimage attack), or birthday attack.
-    group: Community Scanners
-    name: cwe-328
-    pretty_name: "CWE-328: CWE-328: Use of Weak Hash"
+    group: CWE Top 25
+    name: CWE-328
+    pretty_name: CWE-328 - Use of Weak Hash
     ref: https://cwe.mitre.org/data/definitions/328.html
-  cwe-352:
+  CWE-352:
     categories:
       - ALL
       - cwe-352
     description: The web application does not, or can not, sufficiently verify whether a well-formed, valid, consistent request was intentionally provided by the user who submitted the request.
-    group: Community Scanners
-    name: cwe-352
-    pretty_name: "CWE-352: Cross-Site Request Forgery (CSRF)"
+    group: CWE Top 25
+    name: CWE-352
+    pretty_name: CWE-352 - Cross-Site Request Forgery (CSRF)
     ref: https://cwe.mitre.org/data/definitions/352.html
-  cwe-369:
+  CWE-369:
     categories:
       - ALL
       - cwe-369
     description: The product divides a value by zero.
-    group: Community Scanners
-    name: cwe-369
-    pretty_name: "CWE-369: CWE-369: Divide By Zero"
+    group: CWE Top 25
+    name: CWE-369
+    pretty_name: CWE-369 - Divide By Zero
     ref: https://cwe.mitre.org/data/definitions/369.html
-  cwe-399:
+  CWE-399:
     categories:
       - ALL
       - cwe-399
     description: Weaknesses in this category are related to improper management of system resources.
-    group: Community Scanners
-    name: cwe-399
-    pretty_name: "CWE-399: CWE-399: Resource Management Errors"
+    group: CWE Top 25
+    name: CWE-399
+    pretty_name: CWE-399 - Resource Management Errors
     ref: https://cwe.mitre.org/data/definitions/399.html
-  cwe-470:
+  CWE-470:
     categories:
       - ALL
       - cwe-470
     description: The application uses external input with reflection to select which classes or code to use, but it does not sufficiently prevent the input from selecting improper classes or code.
-    group: Community Scanners
-    name: cwe-470
-    pretty_name: "CWE-470: Use of Externally-Controlled Input to Select Classes or Code"
+    group: CWE Top 25
+    name: CWE-470
+    pretty_name: CWE-470 - Use of Externally-Controlled Input to Select Classes or Code
     ref: https://cwe.mitre.org/data/definitions/470.html
-  cwe-502:
+  CWE-502:
     categories:
       - ALL
       - cwe-502
     description: The application deserializes untrusted data without sufficiently verifying that the resulting data will be valid.
-    group: Community Scanners
-    name: cwe-502
-    pretty_name: "CWE-502: Deserialization of Untrusted Data"
+    group: CWE Top 25
+    name: CWE-502
+    pretty_name: CWE-502 - Deserialization of Untrusted Data
     ref: https://cwe.mitre.org/data/definitions/502.html
-  cwe-565:
+  CWE-565:
     categories:
       - ALL
       - cwe-565
     description: The application relies on the existence or values of cookies when performing security-critical operations, but it does not properly ensure that the setting is valid for the associated user.
-    group: Community Scanners
-    name: cwe-565
-    pretty_name: "CWE-565: Reliance on Cookies without Validation and Integrity Checking"
+    group: CWE Top 25
+    name: CWE-565
+    pretty_name: CWE-565 - Reliance on Cookies without Validation and Integrity Checking
     ref: https://cwe.mitre.org/data/definitions/565.html
-  cwe-601:
+  CWE-601:
     categories:
       - ALL
       - cwe-601
     description: A web application accepts a user-controlled input that specifies a link to an external site, and uses that link in a Redirect. This simplifies phishing attacks.
-    group: Community Scanners
-    name: cwe-601
-    pretty_name: "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
+    group: CWE Top 25
+    name: CWE-601
+    pretty_name: CWE-601 - URL Redirection to Untrusted Site ('Open Redirect')
     ref: https://cwe.mitre.org/data/definitions/601.html
-  cwe-614:
+  CWE-614:
     categories:
       - ALL
       - cwe-614
     description: The Secure attribute for sensitive cookies in HTTPS sessions is not set, which could cause the user agent to send those cookies in plaintext over an HTTP session.
-    group: Community Scanners
-    name: cwe-614
-    pretty_name: "CWE-614: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute"
+    group: CWE Top 25
+    name: CWE-614
+    pretty_name: CWE-614 - Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
     ref: https://cwe.mitre.org/data/definitions/614.html
-  cwe-74:
+  CWE-74:
     categories:
       - ALL
       - cwe-74
     description: The software constructs all or part of a command, data structure, or record using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify how it is parsed or interpreted when it is sent to a downstream component.
-    group: Community Scanners
-    name: cwe-74
-    pretty_name: "CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')"
+    group: CWE Top 25
+    name: CWE-74
+    pretty_name: CWE-74 - Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
     ref: https://cwe.mitre.org/data/definitions/74.html
-  cwe-77:
+  CWE-77:
     categories:
       - ALL
       - cwe-77
     description: The software constructs all or part of a command using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended command when it is sent to a downstream component.
-    group: Community Scanners
-    name: cwe-77
-    pretty_name: "CWE-77: Command Injection"
+    group: CWE Top 25
+    name: CWE-77
+    pretty_name: CWE-77 - Command Injection
     ref: https://cwe.mitre.org/data/definitions/77.html
-  cwe-777:
+  CWE-777:
     categories:
       - ALL
       - cwe-777
     description: The software uses a regular expression to perform neutralization, but the regular expression is not anchored and may allow malicious or malformed data to slip through.
-    group: Community Scanners
-    name: cwe-777
-    pretty_name: "CWE-777: Regular Expression without Anchors"
+    group: CWE Top 25
+    name: CWE-777
+    pretty_name: CWE-777 - Regular Expression without Anchors
     ref: https://cwe.mitre.org/data/definitions/777.html
-  cwe-79:
+  CWE-79:
     categories:
       - ALL
       - cwe-79
     description: The software does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users.
-    group: Community Scanners
-    name: cwe-79
-    pretty_name: "CWE-79: Cross-site Scripting (XSS)"
+    group: CWE Top 25
+    name: CWE-79
+    pretty_name: CWE-79 - Cross-site Scripting (XSS)
     ref: https://cwe.mitre.org/data/definitions/79.html
-  cwe-798:
+  CWE-798:
     categories:
       - ALL
       - cwe-798
     description: The software contains hard-coded credentials, such as a password or cryptographic key, which it uses for its own inbound authentication, outbound communication to external components, or encryption of internal data.
-    group: Community Scanners
-    name: cwe-798
-    pretty_name: "CWE-798: Use of Hard-coded Credentials"
+    group: CWE Top 25
+    name: CWE-798
+    pretty_name: CWE-798 - Use of Hard-coded Credentials
     ref: https://cwe.mitre.org/data/definitions/798.html
-  cwe-89:
+  CWE-89:
     categories:
       - ALL
       - cwe-89
     description: The software constructs all or part of an SQL command using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended SQL command when it is sent to a downstream component.
-    group: Community Scanners
-    name: cwe-89
-    pretty_name: "CWE-89: SQL Injection"
+    group: CWE Top 25
+    name: CWE-89
+    pretty_name: CWE-89 - SQL Injection
     ref: https://cwe.mitre.org/data/definitions/89.html
-  cwe-913:
+  CWE-913:
     categories:
       - ALL
       - cwe-913
     description: The software does not properly restrict reading from or writing to dynamically-managed code resources such as variables, objects, classes, attributes, functions, or executable instructions or statements.
-    group: Community Scanners
-    name: cwe-913
-    pretty_name: "CWE-913: Improper Control of Dynamically-Managed Code Resources"
+    group: CWE Top 25
+    name: CWE-913
+    pretty_name: CWE-913 - Improper Control of Dynamically-Managed Code Resources
     ref: https://cwe.mitre.org/data/definitions/913.html
-  cwe-915:
+  CWE-915:
     categories:
       - ALL
       - cwe-915
     description: The software receives input from an upstream component that specifies multiple attributes, properties, or fields that are to be initialized or updated in an object, but it does not properly control which attributes can be modified.
-    group: Community Scanners
-    name: cwe-915
-    pretty_name: "CWE-915: Use of Incorrectly-Resolved Name or Reference"
+    group: CWE Top 25
+    name: CWE-915
+    pretty_name: CWE-915 - Use of Incorrectly-Resolved Name or Reference
     ref: https://cwe.mitre.org/data/definitions/915.html
-  cwe-94:
+  CWE-94:
     categories:
       - ALL
       - cwe-94
     description: The software constructs all or part of a code segment using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the syntax or behavior of the intended code segment.
-    group: Community Scanners
-    name: cwe-94
-    pretty_name: "CWE-94: Improper Control of Generation of Code ('Code Injection')"
+    group: CWE Top 25
+    name: CWE-94
+    pretty_name: CWE-94 - Improper Control of Generation of Code ('Code Injection')
     ref: https://cwe.mitre.org/data/definitions/94.html
-  cwe-95:
+  CWE-95:
     categories:
       - ALL
       - cwe-95
     description: The software receives input from an upstream component, but it does not neutralize or incorrectly neutralizes code syntax before using the input in a dynamic evaluation call (e.g. "eval").
-    group: Community Scanners
-    name: cwe-95
-    pretty_name: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+    group: CWE Top 25
+    name: CWE-95
+    pretty_name: CWE-95 - Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
     ref: https://cwe.mitre.org/data/definitions/95.html


### PR DESCRIPTION
- Updated Docker:
  - Fix CWE ID to upper case (https://github.com/boostsecurityio/boostsec-scanner-brakeman/pull/4)
  - Fix Rule ID in SARIF to be like BRAKE00XX (https://github.com/boostsecurityio/boostsec-scanner-brakeman/pull/6)
- Updated rules.yaml to match the same pattern as semgrep (capitalized)

Tested here https://github.com/boost-sandbox/railsgoat/actions/runs/3270448105/jobs/5379078633#step:3:34