### PR TITLE
Update CodeQL and GitLeaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@
 ### [Trivy](scanners/boostsecurityio/trivy-image)
 
 ### [Trivy-SBOM](scanners/boostsecurityio/trivy-sbom)
+
+### [CodeQL](scanners/boostsecurityio/codeql)
+
+### [GitLeaks](scanners/boostsecurityio/gitleaks)

--- a/scanners/boostsecurityio/codeql/module.yaml
+++ b/scanners/boostsecurityio/codeql/module.yaml
@@ -60,7 +60,7 @@ steps:
 
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-codeql:ba9f188@sha256:a37637c8d187499ef5b2ba8b5daf1dee0cb28b94f14bfc3919299e94dd1b4235
+          image: public.ecr.aws/boostsecurityio/boost-scanner-codeql:23730f6@sha256:2f842549ef18903bc38fe4410d3fffccb8438155618c3a1be8d5ddc73a778d7f
           command: process
           environment:
             PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/gitleaks/README.md
+++ b/scanners/boostsecurityio/gitleaks/README.md
@@ -1,0 +1,8 @@
+# boostsecurityio/codeql
+
+## Environment variables
+
+### `GITLEAKS_CONFIG`
+By default GitLeaks will look for a configuration file named `.gitleaks.toml` at the root of the repository. If the configuration is placed elsewhere, use `GITLEAKS_CONFIG` to set the path in the repository to the GitLeaks configuration to use.
+
+If no configuration is provided, GitLeaks will use its default configuration file.

--- a/scanners/boostsecurityio/gitleaks/module.yaml
+++ b/scanners/boostsecurityio/gitleaks/module.yaml
@@ -21,4 +21,4 @@ steps:
       post-processor:
         docker:
           command: process
-          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:903446f@sha256:63c712573f2e1dd921a58c5041d94c9ba9306320520e92aac00340b134065706
+          image: public.ecr.aws/boostsecurityio/boost-scanner-gitleaks:e5b6dd4@sha256:17ad7652bc7e72bb538551e7c7afbd430c1e3240561753b4747edf08972107bb


### PR DESCRIPTION
- Update CodeQL and GitLeaks to the latest version that includes a fix that removes the taxonomy names. 
- Add CodeQL and GitLeaks to the README.md
- Document how to use GitLeaks environment variables