### PR TITLE
Add initial bundler-audit module

### DIFF
--- a/scanners/boostsecurityio/bundler-audit/README.md
+++ b/scanners/boostsecurityio/bundler-audit/README.md
@@ -1,0 +1,7 @@
+# bundler-audit
+
+## Environment variables
+
+### `GEMFILE_LOCK`
+Path to a custom Gemfile.lock file.
+

--- a/scanners/boostsecurityio/bundler-audit/module.yaml
+++ b/scanners/boostsecurityio/bundler-audit/module.yaml
@@ -28,7 +28,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-            image: public.ecr.aws/boostsecurityio/boost-scanner-bundler-audit:ee8f772@sha256:9d24effc02c96b42ccadaffd886ba5e994efea09b5740dabeb124fe915f406e9
+            image: public.ecr.aws/boostsecurityio/boost-scanner-bundler-audit:6098d7b@sha256:8fa2e319ce8697af0c56e32f8506f753dde6746b9629e20c172eb599a38b518d
             command: process
             environment:
                 GEMFILE_LOCK: ${GEMFILE_LOCK:-Gemfile.lock}

--- a/scanners/boostsecurityio/bundler-audit/module.yaml
+++ b/scanners/boostsecurityio/bundler-audit/module.yaml
@@ -1,0 +1,35 @@
+api_version: 1.0
+
+
+id: boostsecurityio/bundler-audit
+name: Boost bundler-audit Scanner
+namespace: boostsecurityio/bundler-audit
+
+
+config:
+  support_diff_scan: true
+  include_files:
+    - Gemfile
+    - ${GEMFILE_LOCK:-Gemfile.lock}
+
+steps:
+  - scan:
+      command:
+        docker:
+          image: ruby:3.1.2@sha256:933ec5cdaeae085292f00f69fd923f680f9d5a82959db74687cbbbd403b85a19
+          command: |
+            bash -c 'touch Gemfile &&
+                     gem install --silent bundler-audit -v "0.9.1" &&
+                     (bundler-audit check --gemfile-lock="$GEMFILE_LOCK" --quiet --update --format json /src || true)'
+          workdir: /src
+          environment:
+            HOME: /tmp
+            GEMFILE_LOCK: ${GEMFILE_LOCK:-Gemfile.lock}
+      format: sarif
+      post-processor:
+        docker:
+            image: public.ecr.aws/boostsecurityio/boost-scanner-bundler-audit:ee8f772@sha256:9d24effc02c96b42ccadaffd886ba5e994efea09b5740dabeb124fe915f406e9
+            command: process
+            environment:
+                GEMFILE_LOCK: ${GEMFILE_LOCK:-Gemfile.lock}
+                PYTHONIOENCODING: utf-8

--- a/scanners/boostsecurityio/bundler-audit/rules.yaml
+++ b/scanners/boostsecurityio/bundler-audit/rules.yaml
@@ -6,7 +6,7 @@ rules:
       - supply-chain
     description: Dependency with a Vulnerability of Unknown Risk
     name: cve-unknown
-    group: Known Vulnerable Components
+    group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
     ref: https://github.com/rubysec/ruby-advisory-db
   cve-low:
@@ -16,7 +16,7 @@ rules:
       - supply-chain
     description: Dependency with a Low Risk Vulnerability
     name: cve-low
-    group: Known Vulnerable Components
+    group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
     ref: https://github.com/rubysec/ruby-advisory-db
   cve-moderate:
@@ -26,7 +26,7 @@ rules:
       - supply-chain
     description: Dependency with a Medium Risk Vulnerability
     name: cve-moderate
-    group: Known Vulnerable Components
+    group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
     ref: https://github.com/rubysec/ruby-advisory-db
   cve-high:
@@ -37,7 +37,7 @@ rules:
       - supply-chain
     description: Dependency with a High Risk Vulnerability
     name: cve-high
-    group: Known Vulnerable Components
+    group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
     ref: https://github.com/rubysec/ruby-advisory-db
   cve-critical:
@@ -48,6 +48,6 @@ rules:
       - supply-chain
     description: Dependency with a Critical Vulnerability
     name: cve-critical
-    group: Known Vulnerable Components
+    group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
     ref: https://github.com/rubysec/ruby-advisory-db

--- a/scanners/boostsecurityio/bundler-audit/rules.yaml
+++ b/scanners/boostsecurityio/bundler-audit/rules.yaml
@@ -1,0 +1,53 @@
+rules:
+  cve-unknown:
+    categories:
+      - ALL
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a Vulnerability of Unknown Risk
+    name: cve-unknown
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a Vulnerability of Unknown Risk
+    ref: https://github.com/rubysec/ruby-advisory-db
+  cve-low:
+    categories:
+      - ALL
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a Low Risk Vulnerability
+    name: cve-low
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a Low Risk Vulnerability
+    ref: https://github.com/rubysec/ruby-advisory-db
+  cve-moderate:
+    categories:
+      - ALL
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a Medium Risk Vulnerability
+    name: cve-moderate
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a Medium Risk Vulnerability
+    ref: https://github.com/rubysec/ruby-advisory-db
+  cve-high:
+    categories:
+      - ALL
+      - boost-baseline
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a High Risk Vulnerability
+    name: cve-high
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a High Risk Vulnerability
+    ref: https://github.com/rubysec/ruby-advisory-db
+  cve-critical:
+    categories:
+      - ALL
+      - boost-baseline
+      - boost-hardened
+      - supply-chain
+    description: Dependency with a Critical Vulnerability
+    name: cve-critical
+    group: Known Vulnerable Components
+    pretty_name: Dependency with a Critical Vulnerability
+    ref: https://github.com/rubysec/ruby-advisory-db


### PR DESCRIPTION
Copy over the bundler-audit module from https://github.com/boostsecurityio/scanner-testing/pull/49. I need this module in this registry to test on entropy orgs.