### PR TITLE
Update npm-audit post-processor

### DIFF
--- a/scanners/boostsecurityio/npm-audit/module.yaml
+++ b/scanners/boostsecurityio/npm-audit/module.yaml
@@ -25,7 +25,7 @@ steps:
       format: sarif
       post-processor:
         docker:
-            image: public.ecr.aws/boostsecurityio/boost-converter-sca:afa5ff5@sha256:feb55d009d24b6f40b24c622481f0020c8f5eccbe7f70c0a2d3dbb0565a3ac4e
+            image: public.ecr.aws/boostsecurityio/boost-converter-sca:335f358@sha256:a59f3ce62d5fabacb9cefd3fdd92862f07f47f3956514aac4c5d78ce7901f275
             command: |
               process --scanner npm-audit
             environment:


### PR DESCRIPTION
SCA findings will now be reported as high confidence.

Ignore the branch name, it's actually for npm audit.