### PR TITLE
BST-3182 - Aligned all SCA related rules and labels

### DIFF
--- a/scanners/boostsecurityio/brakeman/rules.yaml
+++ b/scanners/boostsecurityio/brakeman/rules.yaml
@@ -23,6 +23,7 @@ rules:
       - cwe-1104
       - boost-baseline
       - boost-hardened
+      - vulnerable-and-outdated-components
     description: The product relies on third-party components that are not actively supported or maintained by the original developer or a trusted proxy for the original developer.
     group: top10-vulnerable-components
     name: CWE-1104

--- a/scanners/boostsecurityio/bundler-audit/rules.yaml
+++ b/scanners/boostsecurityio/bundler-audit/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss

--- a/scanners/boostsecurityio/bundler-audit/rules.yaml
+++ b/scanners/boostsecurityio/bundler-audit/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://github.com/rubysec/ruby-advisory-db
+    ref: https://nvd.nist.gov/vuln/search
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://github.com/rubysec/ruby-advisory-db
+    ref: https://nvd.nist.gov/vuln/search
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://github.com/rubysec/ruby-advisory-db
+    ref: https://nvd.nist.gov/vuln/search
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://github.com/rubysec/ruby-advisory-db
+    ref: https://nvd.nist.gov/vuln/search
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://github.com/rubysec/ruby-advisory-db
+    ref: https://nvd.nist.gov/vuln/search

--- a/scanners/boostsecurityio/nancy/rules.yaml
+++ b/scanners/boostsecurityio/nancy/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://ossindex.sonatype.org/
+    ref: https://nvd.nist.gov/vuln/search
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://ossindex.sonatype.org/
+    ref: https://nvd.nist.gov/vuln/search
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://ossindex.sonatype.org/
+    ref: https://nvd.nist.gov/vuln/search
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://ossindex.sonatype.org/
+    ref: https://nvd.nist.gov/vuln/search
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://ossindex.sonatype.org/
+    ref: https://nvd.nist.gov/vuln/search

--- a/scanners/boostsecurityio/nancy/rules.yaml
+++ b/scanners/boostsecurityio/nancy/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss

--- a/scanners/boostsecurityio/npm-audit/rules.yaml
+++ b/scanners/boostsecurityio/npm-audit/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://github.com/advisories
+    ref: https://nvd.nist.gov/vuln/search
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://github.com/advisories
+    ref: https://nvd.nist.gov/vuln/search
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://github.com/advisories
+    ref: https://nvd.nist.gov/vuln/search
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://github.com/advisories
+    ref: https://nvd.nist.gov/vuln/search
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://github.com/advisories
+    ref: https://nvd.nist.gov/vuln/search

--- a/scanners/boostsecurityio/npm-audit/rules.yaml
+++ b/scanners/boostsecurityio/npm-audit/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss

--- a/scanners/boostsecurityio/safety/rules.yaml
+++ b/scanners/boostsecurityio/safety/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss

--- a/scanners/boostsecurityio/safety/rules.yaml
+++ b/scanners/boostsecurityio/safety/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://github.com/pyupio/safety
+    ref: https://nvd.nist.gov/vuln/search
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://github.com/pyupio/safety
+    ref: https://nvd.nist.gov/vuln/search
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://github.com/pyupio/safety
+    ref: https://nvd.nist.gov/vuln/search
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://github.com/pyupio/safety
+    ref: https://nvd.nist.gov/vuln/search
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://github.com/pyupio/safety
+    ref: https://nvd.nist.gov/vuln/search

--- a/scanners/boostsecurityio/snyk-test/rules.yaml
+++ b/scanners/boostsecurityio/snyk-test/rules.yaml
@@ -1,4 +1,15 @@
 rules:
+  cve-unknown:
+    categories:
+      - ALL
+      - boost-hardened
+      - supply-chain
+      - vulnerable-and-outdated-components
+    description: Dependency with a Vulnerability of Unknown Risk
+    name: cve-unknown
+    group: top10-vulnerable-components
+    pretty_name: Dependency with a Vulnerability of Unknown Risk
+    ref: https://nvd.nist.gov/vuln/search
   cve-low:
     categories:
       - ALL
@@ -9,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://docs.boostsecurity.net
+    ref: https://nvd.nist.gov/vuln/search
   cve-moderate:
     categories:
       - ALL
@@ -20,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://docs.boostsecurity.net
+    ref: https://nvd.nist.gov/vuln/search
   cve-high:
     categories:
       - ALL
@@ -32,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://docs.boostsecurity.net
+    ref: https://nvd.nist.gov/vuln/search
   cve-critical:
     categories:
       - ALL
@@ -44,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://docs.boostsecurity.net
+    ref: https://nvd.nist.gov/vuln/search

--- a/scanners/boostsecurityio/snyk-test/rules.yaml
+++ b/scanners/boostsecurityio/snyk-test/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss

--- a/scanners/boostsecurityio/trivy-image/rules.yaml
+++ b/scanners/boostsecurityio/trivy-image/rules.yaml
@@ -9,7 +9,7 @@ rules:
     name: cve-unknown
     group: top10-vulnerable-components
     pretty_name: Dependency with a Vulnerability of Unknown Risk
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-low:
     categories:
       - ALL
@@ -20,7 +20,7 @@ rules:
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-moderate:
     categories:
       - ALL
@@ -31,7 +31,7 @@ rules:
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-high:
     categories:
       - ALL
@@ -43,7 +43,7 @@ rules:
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss
   cve-critical:
     categories:
       - ALL
@@ -55,4 +55,4 @@ rules:
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://nvd.nist.gov/vuln/search
+    ref: https://nvd.nist.gov/vuln-metrics/cvss

--- a/scanners/boostsecurityio/trivy-image/rules.yaml
+++ b/scanners/boostsecurityio/trivy-image/rules.yaml
@@ -1,43 +1,58 @@
 rules:
+  cve-unknown:
+    categories:
+      - ALL
+      - boost-hardened
+      - supply-chain
+      - vulnerable-and-outdated-components
+    description: Dependency with a Vulnerability of Unknown Risk
+    name: cve-unknown
+    group: top10-vulnerable-components
+    pretty_name: Dependency with a Vulnerability of Unknown Risk
+    ref: https://nvd.nist.gov/vuln/search
   cve-low:
     categories:
       - ALL
       - boost-hardened
       - supply-chain
+      - vulnerable-and-outdated-components
     description: Dependency with a Low Risk Vulnerability
     name: cve-low
     group: top10-vulnerable-components
     pretty_name: Dependency with a Low Risk Vulnerability
-    ref: https://docs.boostsecurity.net
+    ref: https://nvd.nist.gov/vuln/search
   cve-moderate:
     categories:
       - ALL
       - boost-hardened
       - supply-chain
+      - vulnerable-and-outdated-components
     description: Dependency with a Medium Risk Vulnerability
     name: cve-moderate
     group: top10-vulnerable-components
     pretty_name: Dependency with a Medium Risk Vulnerability
-    ref: https://docs.boostsecurity.net
+    ref: https://nvd.nist.gov/vuln/search
   cve-high:
     categories:
       - ALL
       - boost-baseline
       - boost-hardened
       - supply-chain
+      - vulnerable-and-outdated-components
     description: Dependency with a High Risk Vulnerability
     name: cve-high
     group: top10-vulnerable-components
     pretty_name: Dependency with a High Risk Vulnerability
-    ref: https://docs.boostsecurity.net
+    ref: https://nvd.nist.gov/vuln/search
   cve-critical:
     categories:
       - ALL
       - boost-baseline
       - boost-hardened
       - supply-chain
+      - vulnerable-and-outdated-components
     description: Dependency with a Critical Vulnerability
     name: cve-critical
     group: top10-vulnerable-components
     pretty_name: Dependency with a Critical Vulnerability
-    ref: https://docs.boostsecurity.net
+    ref: https://nvd.nist.gov/vuln/search


### PR DESCRIPTION
Aligned all SCA related rules to have the same labels and groups (also one rule in Brakeman matches some CVEs)

Since we will eventually move those to a shared namespace (instead of copy pasting), I put a generic URL for the documentation. And since we had nothing really interesting anyway for the documentation, I'm sending people to the NIST NVD page explaining CVSS mapping to low, medium, high, critical, etc...