### PR TITLE
BST-3168, BST-3170, BST-3172 - Align and add missing boost-baseline / boost-hardened 

### DIFF
--- a/scanners/boostsecurityio/codeql/rules.yaml
+++ b/scanners/boostsecurityio/codeql/rules.yaml
@@ -161,13 +161,13 @@ rules:
   CWE-798:
     categories:
     - ALL
-      - stored-secrets
-      - cwe-top-25
-      - boost-baseline
-      - boost-hardened
-      - cwe-200
-      - cwe-798
-      - cwe-522
+    - stored-secrets
+    - cwe-top-25
+    - boost-baseline
+    - boost-hardened
+    - cwe-200
+    - cwe-798
+    - cwe-522
     group: top10-id-authn-failures
     name: CWE-798
     pretty_name: CWE-798 - Use of Hard-coded Credentials

--- a/scanners/boostsecurityio/codeql/rules.yaml
+++ b/scanners/boostsecurityio/codeql/rules.yaml
@@ -3,6 +3,8 @@ rules:
     categories:
       - ALL
       - cwe-1336
+      - boost-baseline
+      - boost-hardened
     description: The product uses a template engine to insert or process externally-influenced input, but it does not neutralize or incorrectly neutralizes special elements or syntax that can be interpreted as template expressions or other code directives when processed.
     group: top10-injection
     name: CWE-1336
@@ -12,6 +14,7 @@ rules:
     categories:
       - ALL
       - cwe-285
+      - boost-hardened
     description: The software does not perform or incorrectly performs an authorization check when an actor attempts to access a resource or perform an action.
     group: top10-broken-access-control
     name: CWE-285
@@ -21,6 +24,8 @@ rules:
     categories:
       - ALL
       - cwe-259
+      - boost-baseline
+      - boost-hardened
     description: The software contains a hard-coded password, which it uses for its own inbound authentication or for outbound communication to external components.
     group: top10-id-authn-failures
     name: CWE-259
@@ -376,6 +381,7 @@ rules:
     categories:
     - ALL
     - cwe-1236
+    - boost-hardened
     group: top10-injection
     name: CWE-1236
     pretty_name: CWE-1236 - Improper Neutralization of Formula Elements in a CSV File
@@ -398,6 +404,8 @@ rules:
     categories:
     - ALL
     - cwe-116
+    - boost-baseline
+    - boost-hardened
     group: top10-injection
     name: CWE-116
     pretty_name: CWE-116 - Improper Encoding or Escaping of Output
@@ -416,6 +424,8 @@ rules:
     categories:
     - ALL
     - cwe-943
+    - boost-baseline
+    - boost-hardened
     group: top10-injection
     name: CWE-943
     pretty_name: CWE-943 - Improper Neutralization of Special Elements in Data Query

--- a/scanners/boostsecurityio/codeql/rules.yaml
+++ b/scanners/boostsecurityio/codeql/rules.yaml
@@ -23,9 +23,14 @@ rules:
   CWE-259:
     categories:
       - ALL
-      - cwe-259
+      - stored-secrets
+      - cwe-top-25
       - boost-baseline
       - boost-hardened
+      - cwe-259
+      - cwe-200
+      - cwe-798
+      - cwe-522
     description: The software contains a hard-coded password, which it uses for its own inbound authentication or for outbound communication to external components.
     group: top10-id-authn-failures
     name: CWE-259
@@ -80,6 +85,7 @@ rules:
     categories:
     - ALL
     - cwe-778
+    - boost-hardened
     group: top10-security-logging-monitoring-failures
     name: CWE-778
     pretty_name: CWE-778 - Insufficient Logging
@@ -155,10 +161,13 @@ rules:
   CWE-798:
     categories:
     - ALL
-    - cwe-top-25
-    - cwe-798
-    - boost-baseline
-    - boost-hardened
+      - stored-secrets
+      - cwe-top-25
+      - boost-baseline
+      - boost-hardened
+      - cwe-200
+      - cwe-798
+      - cwe-522
     group: top10-id-authn-failures
     name: CWE-798
     pretty_name: CWE-798 - Use of Hard-coded Credentials
@@ -468,6 +477,7 @@ rules:
     categories:
     - ALL
     - cwe-915
+    - boost-hardened
     group: top10-software-data-integrity-failures
     name: CWE-915
     pretty_name: CWE-915 - Improperly Controlled Modification of Dynamically-Determined
@@ -563,6 +573,7 @@ rules:
   CWE-UNKNOWN:
     categories:
     - ALL
+    - boost-hardened
     group: top10-insecure-design
     name: CWE-UNKNOWN
     pretty_name: CWE-UNKNOWN - Original rule did not map to a known CWE rule

--- a/scanners/boostsecurityio/gitleaks/rules.yaml
+++ b/scanners/boostsecurityio/gitleaks/rules.yaml
@@ -7,4 +7,10 @@ rules:
     description: The repository exposes sensitive information to an actor that is not explicitly authorized to have access to that information.
     categories:
       - ALL
+      - stored-secrets
+      - cwe-top-25
+      - boost-baseline
+      - boost-hardened
       - cwe-200
+      - cwe-798
+      - cwe-522

--- a/scanners/boostsecurityio/gosec/rules.yaml
+++ b/scanners/boostsecurityio/gosec/rules.yaml
@@ -69,6 +69,8 @@ rules:
     categories:
       - ALL
       - cwe-918
+      - boost-baseline
+      - boost-hardened
     group: top10-server-side-request-forgery
     name: G107
     pretty_name: "G107: Url provided to HTTP request as taint input"
@@ -102,7 +104,8 @@ rules:
   G601:
     categories:
       - ALL
-      - cwe-119
+      - cwe-118
+      - boost-hardened
     group: top10-insecure-design
     name: G601
     pretty_name: "G601: Implicit memory aliasing of items from a range statement"
@@ -112,7 +115,8 @@ rules:
   G109:
     categories:
       - ALL
-      - cwe-119
+      - cwe-190
+      - boost-hardened
     group: top10-insecure-design
     name: G109
     pretty_name: "G109: Potential Integer overflow made by strconv.Atoi result conversion to int16/32"
@@ -123,11 +127,12 @@ rules:
     categories:
       - ALL
       - cwe-704
+      - boost-hardened
     group: top10-insecure-design
     name: G113
     pretty_name: "G113: Usage of Rat.SetString in math/big with an overflow (CVE-2022-23772)"
     description: The software performs a calculation that can produce an integer overflow or wraparound.
-    ref: https://cwe.mitre.org/data/definitions/190.html
+    ref: https://cwe.mitre.org/data/definitions/704.html
 
   G102:
     categories:
@@ -142,18 +147,25 @@ rules:
   G108:
     categories:
       - ALL
-      - cwe-200
-      - cwe-489
+      - cwe-top-25
+      - owasp-top-10
+      - boost-baseline
+      - boost-hardened
+      - cwe-489 # Active debug code
+      - cwe-200 # Exposure of Sensitive Information
+      - cwe-732 # Incorrect Permissions
+      - cwe-287 # Improper Authentication on Critical Resource
     group: top10-security-misconfiguration
     name: G108
     pretty_name: "G108: Profiling endpoint automatically exposed on /debug/pprof"
     description: The product exposes sensitive information to an actor that is not explicitly authorized to have access to that information.
-    ref: https://cwe.mitre.org/data/definitions/200.html
+    ref: https://cwe.mitre.org/data/definitions/489.html
 
   G103:
     categories:
       - ALL
       - cwe-119
+      - cwe-242
     group: top10-insecure-design
     name: G103
     pretty_name: "G103: Audit the use of unsafe block"
@@ -194,6 +206,10 @@ rules:
     categories:
       - ALL
       - cwe-295
+      - cwe-top-25
+      - owasp-top-10
+      - boost-baseline
+      - boost-hardened
     group: top10-id-authn-failures
     name: G402
     pretty_name: "G402: Look for bad TLS connection settings"
@@ -204,6 +220,8 @@ rules:
     categories:
       - ALL
       - cwe-310
+      - boost-baseline
+      - boost-hardened
     group: top10-crypto-failures
     name: G403
     pretty_name: "G403: Ensure minimum RSA key length of 2048 bits"
@@ -214,6 +232,8 @@ rules:
     categories:
       - ALL
       - cwe-295
+      - boost-baseline
+      - boost-hardened
     group: top10-id-authn-failures
     name: G106
     pretty_name: "G106: Audit the use of ssh.InsecureIgnoreHostKey"
@@ -224,6 +244,7 @@ rules:
     categories:
       - ALL
       - cwe-326
+      - boost-hardened
     group: top10-crypto-failures
     name: G401
     pretty_name: "G401: Detect the usage of DES, RC4, MD5 or SHA1"
@@ -234,6 +255,7 @@ rules:
     categories:
       - ALL
       - cwe-327
+      - boost-hardened
     group: top10-crypto-failures
     name: G501
     pretty_name: "G501: Import blocklist: crypto/md5"
@@ -244,6 +266,8 @@ rules:
     categories:
       - ALL
       - cwe-327
+      - boost-baseline
+      - boost-hardened
     group: top10-crypto-failures
     name: G502
     pretty_name: "G502: Import blocklist: crypto/des"
@@ -254,6 +278,8 @@ rules:
     categories:
       - ALL
       - cwe-327
+      - boost-baseline
+      - boost-hardened
     group: top10-crypto-failures
     name: G503
     pretty_name: "G503: Import blocklist: crypto/rc4"
@@ -264,6 +290,8 @@ rules:
     categories:
       - ALL
       - cwe-327
+      - boost-baseline
+      - boost-hardened
     group: top10-crypto-failures
     name: G504
     pretty_name: "G504: Import blocklist: net/http/cgi"
@@ -274,6 +302,7 @@ rules:
     categories:
       - ALL
       - cwe-327
+      - boost-hardened
     group: top10-crypto-failures
     name: G505
     pretty_name: "G505: Import blocklist: crypto/sha1"
@@ -284,6 +313,8 @@ rules:
     categories:
       - ALL
       - cwe-338
+      - boost-baseline
+      - boost-hardened
     group: top10-crypto-failures
     name: G404
     pretty_name: "G404: Insecure random number source (rand)"
@@ -345,6 +376,8 @@ rules:
     categories:
       - ALL
       - cwe-703
+      - boost-baseline
+      - boost-hardened
     group: top10-insecure-design
     name: G307
     pretty_name: "G307: Deferring a method which returns an error"
@@ -354,7 +387,13 @@ rules:
   G101:
     categories:
       - ALL
+      - stored-secrets
+      - cwe-top-25
+      - boost-baseline
+      - boost-hardened
+      - cwe-200
       - cwe-798
+      - cwe-522
     group: top10-id-authn-failures
     name: G101
     pretty_name: "G101: Look for hard coded credentials"

--- a/scanners/boostsecurityio/gosec/rules.yaml
+++ b/scanners/boostsecurityio/gosec/rules.yaml
@@ -45,6 +45,8 @@ rules:
     categories:
       - ALL
       - cwe-78
+      - boost-baseline
+      - boost-hardened
     group: top10-injection
     name: G204
     pretty_name: "G204: Audit use of command execution"
@@ -55,6 +57,8 @@ rules:
     categories:
       - ALL
       - cwe-79
+      - boost-baseline
+      - boost-hardened
     group: top10-injection
     name: G203
     pretty_name: "G203: Use of unescaped data in HTML templates"
@@ -75,6 +79,8 @@ rules:
     categories:
       - ALL
       - cwe-89
+      - boost-baseline
+      - boost-hardened
     group: top10-injection
     name: G201
     pretty_name: "G201: SQL query construction using format string"
@@ -85,6 +91,8 @@ rules:
     categories:
       - ALL
       - cwe-89
+      - boost-baseline
+      - boost-hardened
     group: top10-injection
     name: G202
     pretty_name: "G202: SQL query construction using string concatenation"

--- a/scanners/boostsecurityio/native-scanner/rules.yaml
+++ b/scanners/boostsecurityio/native-scanner/rules.yaml
@@ -1921,6 +1921,7 @@ rules:
       - cwe-top-25
       - boost-baseline
       - boost-hardened
+      - cwe-200
       - cwe-798
       - cwe-522
     description: Checks for secrets and credentials stored in a source code repository.

--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -349,6 +349,7 @@ rules:
     categories:
     - ALL
     - cwe-1236
+    - boost-hardened
     group: top10-injection
     name: CWE-1236
     pretty_name: CWE-1236 - Improper Neutralization of Formula Elements in a CSV File
@@ -371,6 +372,8 @@ rules:
     categories:
     - ALL
     - cwe-116
+    - boost-baseline
+    - boost-hardened
     group: top10-injection
     name: CWE-116
     pretty_name: CWE-116 - Improper Encoding or Escaping of Output
@@ -389,6 +392,8 @@ rules:
     categories:
     - ALL
     - cwe-943
+    - boost-baseline
+    - boost-hardened
     group: top10-injection
     name: CWE-943
     pretty_name: CWE-943 - Improper Neutralization of Special Elements in Data Query

--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -440,6 +440,7 @@ rules:
     categories:
     - ALL
     - cwe-915
+    - boost-hardened
     group: top10-software-data-integrity-failures
     name: CWE-915
     pretty_name: CWE-915 - Improperly Controlled Modification of Dynamically-Determined
@@ -535,6 +536,7 @@ rules:
   CWE-UNKNOWN:
     categories:
     - ALL
+    - boost-hardened
     group: top10-insecure-design
     name: CWE-UNKNOWN
     pretty_name: CWE-UNKNOWN - Original rule did not map to a known CWE rule

--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -48,6 +48,7 @@ rules:
     categories:
     - ALL
     - cwe-778
+    - boost-hardened
     group: top10-security-logging-monitoring-failures
     name: CWE-778
     pretty_name: CWE-778 - Insufficient Logging
@@ -123,10 +124,13 @@ rules:
   CWE-798:
     categories:
     - ALL
+    - stored-secrets
     - cwe-top-25
-    - cwe-798
     - boost-baseline
     - boost-hardened
+    - cwe-200
+    - cwe-798
+    - cwe-522
     group: top10-id-authn-failures
     name: CWE-798
     pretty_name: CWE-798 - Use of Hard-coded Credentials


### PR DESCRIPTION
Also in dev https://github.com/boostsecurityio/scanner-testing/pull/77
---
Normalizing usage of labels:
- for secrets related rules (gitleaks and built-in to native-scanner)
- added missing `boost-baseline` / `boost-hardened` for:
  - CodeQL
  - GoSec
  - semgrep
# Reviewer's notes:
- each aspect has been regrouped by commit, so feel free to filter in the `Files Changed` tab

## Not included:
-  Normalizing `owasp-top-10` , `cwe-top-25` labels is not addressed in this PR