### PR TITLE
[BST-3370] Adds CWE-1333 to semgrep rules db

### DIFF
--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -653,6 +653,18 @@ rules:
       and executes the code without sufficiently verifying the origin and integrity
       of the code.
     ref: https://github.com/returntocorp/semgrep-rules/
+  CWE-1333:
+    categories:
+    - ALL
+    - cwe-1333
+    - boost-baseline
+    - boost-hardened
+    - owasp-top-10
+    group: top10-insecure-design
+    name: CWE-1333
+    pretty_name: CWE-1333 - Inefficient Regular Expression Complexity
+    description: The product uses a regular expression with an inefficient, possibly exponential worst-case computational complexity that consumes excessive CPU cycles.
+    ref: https://github.com/returntocorp/semgrep-rules/
   CWE-UNKNOWN:
     categories:
     - ALL

--- a/scanners/boostsecurityio/semgrep/rules.yaml
+++ b/scanners/boostsecurityio/semgrep/rules.yaml
@@ -657,9 +657,6 @@ rules:
     categories:
     - ALL
     - cwe-1333
-    - boost-baseline
-    - boost-hardened
-    - owasp-top-10
     group: top10-insecure-design
     name: CWE-1333
     pretty_name: CWE-1333 - Inefficient Regular Expression Complexity


### PR DESCRIPTION
there;s a new rule and category added for CWE-1333 for semgrep scanner. On existing projects, the rule being triggered is CWE-UNKONWN, adding support for CWE-1333 enables for clearer description for users. 