### PR TITLE
Add CWE-1333 support for semgrep module

### DIFF
--- a/scanners/boostsecurityio/semgrep/module.yaml
+++ b/scanners/boostsecurityio/semgrep/module.yaml
@@ -23,5 +23,5 @@ steps:
       format: sarif
       post-processor:
         docker:
-          image: public.ecr.aws/boostsecurityio/boost-scanner-semgrep:46808fc@sha256:fc6b3e14d925bde96c8a71f199289f40b6d4737db7203d2ec029fde2c41b2c1f
+          image: public.ecr.aws/boostsecurityio/boost-scanner-semgrep:0dcef38@sha256:5ac5aa92db3b8b46713bb23a7bb3ebcee9f8ac3b29e31a4bce5c58f7a99fdfc9
           command: process


### PR DESCRIPTION
I have tested this on `scanner-testing` already.

Test:
```
cd /tmp
git clone git@github.com:boostsecurityio/boostsec-scanner-cli.git
git clone git@github.com:returntocorp/semgrep-rules.git
cd boostsec-scanner-cli
make install
poetry run boost scan repo --offline --path /tmp/semgrep-rules  --registry-module boostsecurityio/semgrep --registry 'https://github.com/boostsecurityio/scanner-registry#semgrep-add-support-for-cwe-1333' | grep 1333
```

output
```
   "id": "CWE-1333",
                    "id": "CWE-1333",
                    "id": "CWE-1333",
            "boostId/v2": "76de0d2ce087731442fdbd14f4c3f72a13330227f8ec19ae517a95658be91319"
              "id": "CWE-1333",
              "id": "CWE-1333",
              "id": "CWE-1333",
              "id": "CWE-1333",
              "id": "CWE-1333",
            "boostIdHash/v2": "313332470b8f4bbdb080c925d42a7e350a78c04adb6c4c88348578484c01175e"
              "id": "CWE-1333",
              "id": "CWE-1333",
            "boostIdHash/v2": "5e684ac241216c81169d6060030fb4991333b167ba1ba0120b8eb1bfb523ff12"
            "boostIdHash/v2": "5e684ac241216c81169d6060030fb4991333b167ba1ba0120b8eb1bfb523ff12"
            "boostIdHash/v2": "cfa2aa88f1333749633eb7b80625eeb20fe887a1f2d1f28a71b2ecfc621d7c3f"
            "boostId/v2": "cffbdfbf4ead5a76088174af8ccf5aa6133338c48ce11bffd87b3b9cf625ddad"
            "boostIdHash/v2": "54cf86d1333626eeb59c8e6f7d0c95387a93d1d09e881cba96bd3b7f9c052d3f"
              "id": "CWE-1333",
              "id": "CWE-1333",
              "id": "CWE-1333",
              "id": "CWE-1333",
              "id": "CWE-1333",
```